### PR TITLE
feat(history): add charge history with interactive chart + README and size optimizations

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -29,6 +29,8 @@ android {
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName
+        // Package only English resources to reduce size. Add more if you localize.
+        resourceConfigurations += setOf("en")
     }
 
     buildTypes {
@@ -42,12 +44,14 @@ android {
         }
     }
 
-    splits {
-        abi {
-            isEnable = true
-            reset()
-            include("armeabi-v7a", "arm64-v8a", "x86_64")
-            isUniversalApk = true
+    // ABI split configuration removed to avoid conflict with ndk.abiFilters
+    // Prefer building an App Bundle (flutter build appbundle) or use
+    // --split-per-abi at build time.
+
+    packaging {
+        resources {
+            // Exclude common license/notice files not needed at runtime
+            excludes += "/META-INF/{AL2.0,LGPL2.1,DEPENDENCIES,LICENSE,LICENSE.txt,LICENSE.md,NOTICE,NOTICE.txt}"
         }
     }
 }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -5,17 +5,12 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
-    <!-- For loading QR image and opening external links -->
-    <uses-permission android:name="android.permission.INTERNET" />
+    <!-- INTERNET not required for current features (external browser handles network) -->
 
     <application
         android:label="ChargeAlert"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
-        <!-- Foreground service used for continuous alarm playback -->
-        <service
-            android:name="com.pravera.flutter_foreground_task.FlutterForegroundService"
-            android:exported="false" />
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -161,14 +161,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.6"
-  cupertino_icons:
-    dependency: "direct main"
-    description:
-      name: cupertino_icons
-      sha256: ba631d1c7f7bef6b729a622b7b752645a2d076dba9976925b8f25725a30e1ee6
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.8"
   dbus:
     dependency: transitive
     description:
@@ -230,14 +222,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_foreground_task:
-    dependency: "direct main"
-    description:
-      name: flutter_foreground_task
-      sha256: "9f1b25a81db95d7119d2c5cffc654048cbdd49d4056183e1beadc1a6a38f3e29"
-      url: "https://pub.dev"
-    source: hosted
-    version: "9.1.0"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,9 +31,6 @@ dependencies:
   flutter:
     sdk: flutter
 
-  # The following adds the Cupertino Icons font to your application.
-  # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^1.0.8
   flutter_riverpod: ^2.4.8
   battery_plus: ^7.0.0
   flutter_local_notifications: ^19.4.2
@@ -44,8 +41,7 @@ dependencies:
   fl_chart: ^0.69.0
 
   audioplayers: ^6.5.1
-  # wakelock removed (use foreground service to keep device awake)
-  flutter_foreground_task: ^9.1.0
+  # Keep dependencies lean for smaller APK/AAB size
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This PR introduces the Charge History feature and reduces APK size.\n\nHighlights:\n- Charge History page using fl_chart (smooth, interactive)\n- Route + menu entry from Home (AppBar + overflow)\n- Periodic battery sampling with dedupe + 500-entry cap (SharedPreferences)\n- README revamp: badges, TOC, responsive screenshots\n- Android size optimizations: R8 shrink + resource shrinking, limit locales to en, remove universal APK, packaging excludes\n- Dependency cleanup in pubspec\n\nBuild artifacts for verification are attached to Release v1.0.1.\n\nTested: \n- Debug run on device, history page renders with tooltips \n- Split APKs and AAB build successfully.\n\nPlease review.